### PR TITLE
Properly delete card from original list when moving it to another list

### DIFF
--- a/addons/gkanban/pages/ProjectBoard.gd
+++ b/addons/gkanban/pages/ProjectBoard.gd
@@ -348,15 +348,15 @@ func _on_List_move_card_pressed(_list, _card, _direction):
 			var current_index = get_list_index(_list)
 
 			list_container.get_child(current_index-1).add_card(_card.card)
-
+			_list.remove_card(_card.card)
 			_card.queue_free()
 		"right":
 			if list_container.get_child(list_container.get_child_count()-1) == _list:
 				return
 
 			var current_index = get_list_index(_list)
-
 			list_container.get_child(current_index+1).add_card(_card.card)
+			_list.remove_card(_card.card)
 			_card.queue_free()
 
 


### PR DESCRIPTION
This fixes a problem that caused cards to duplicate when moved between lists. I tried to PR into the main branch, but the author doesn't seem active right now. Here's my original PR: https://github.com/kidando/gkanban/pull/7